### PR TITLE
修复一处在php7.1版本中会出现的bug

### DIFF
--- a/application/common/builder/table/Builder.php
+++ b/application/common/builder/table/Builder.php
@@ -957,7 +957,7 @@ class Builder extends ZBuilder
      * @return array|string
      */
     private function compileHtmlAttr($attr = []) {
-        $result = '';
+        $result = [];$index=0;
         if ($attr) {
             foreach ($attr as $key => &$value) {
                 if ($key == 'title') {
@@ -965,7 +965,7 @@ class Builder extends ZBuilder
                 } else {
                     $value = htmlspecialchars($value);
                 }
-                $result[] = "$key=\"$value\"";
+                $result[$index++] = "$key=\"$value\"";
             }
             $result = implode(' ', $result);
         }


### PR DESCRIPTION
php7.1 不再支持空索引操作符 ，且implode方法操作字符串变量时会报错。