### PR TITLE
修复PHP8.0下表格构建器中参数默认值缺失导致不兼容的问题及数组合并时保留关键数组的键而导致调用callback函数报错的问题

### DIFF
--- a/application/common/builder/table/Builder.php
+++ b/application/common/builder/table/Builder.php
@@ -1663,7 +1663,7 @@ class Builder extends ZBuilder
      * @author 蔡伟明 <314013107@qq.com>
      * @return $this
      */
-    public function addTrClass($class = '', $field, $op = null, $condition = null)
+    public function addTrClass($class = '', $field = '', $op = null, $condition = null)
     {
         if ($class != '') {
             if (is_callable($field)) {
@@ -2116,7 +2116,7 @@ class Builder extends ZBuilder
                             $params = array_filter($params, function($v){return $v !== '';});
 
                             if (isset($row[$column['name']]) || array_key_exists($column['name'], $row)) {
-                                $params = array_merge([$row[$column['name']]], $params);
+                                $params = array_merge([$row[$column['name']]], array_values($params));
                             }
 
                             if (!empty($params)) {


### PR DESCRIPTION
基本都是未考虑到PHP8.0的兼容而导致，IDE集成PHP Inspections也能提示出具体问题所在